### PR TITLE
added the ability to cleanup hasOne relationships

### DIFF
--- a/lib/cascade-delete.js
+++ b/lib/cascade-delete.js
@@ -27,10 +27,19 @@ module.exports = function (Model, options) {
       }
 
       return new Promise(function (resolve, reject) {
-        instance[opts.rel].destroyAll(function (err, info) {
-          debug('Relation ', opts.rel, ' deleted with info ', info);
-          resolve(info);
-        });
+          if(typeof instance[opts.rel].destroyAll === 'function') {
+            instance[opts.rel].destroyAll(function (err, info) {
+              debug('Relation ', opts.rel, ' deleted with info ', info);
+              resolve(info);
+            });
+          } else {
+            Model.findOne({id: instance.id, include: opts.rel}, function(err, model) {
+              model[opts.rel].destroy(function(err, info){
+                debug('Relation ', opts.rel, ' deleted with info ', info);
+                resolve(info);
+              });
+            });
+          }
       });
     };
   });


### PR DESCRIPTION
I added the ability to clean up all hasOne relationships.  The testing isn't ideal since I wasn't able to spy the destroy method for the model.
